### PR TITLE
Add ani-man

### DIFF
--- a/mpv_script_directory.json
+++ b/mpv_script_directory.json
@@ -2982,5 +2982,28 @@
         "install_dir": "github/werman/noise-suppression-for-voice",
         "sharedrepo": false,
         "stars": 70943
+    },
+    "github:johndovern/ani-man": {
+        "name": "ani-man",
+        "url": "https://github.com/johndovern/ani-man",
+        "type": "other",
+        "desc": "Offline anime/video progress tracking.",
+        "os": [
+            "Linux"
+        ],
+        "sharedrepo": false,
+        "install": "git",
+        "receiving_url": "https://github.com/johndovern/ani-man.git",
+        "install_dir": "github/johndovern/ani-man",
+        "scriptfiles": [
+            "conf/lua/ani-man.lua"
+        ],
+        "scriptoptfiles": [
+            "conf/lua/ani-man.conf"
+        ],
+        "executablefiles": [
+            "ani-man"
+        ],
+        "install-notes": "To complete the installation please run:\n\tani-man --setup"
     }
 }

--- a/mpv_script_directory.json
+++ b/mpv_script_directory.json
@@ -3004,6 +3004,6 @@
         "executablefiles": [
             "ani-man"
         ],
-        "install-notes": "To complete the installation please run:\n\tani-man --setup"
+        "install-notes": "To complete the installation please run:\n\tani-man --setup\nPlease ensure that ~/bin is in your PATH.\nFor help please run:\n\tani-man --help"
     }
 }


### PR DESCRIPTION
I used the `executablefiles` key to include a bash script that goes along with the lua script. I see this isn't used by any other plugins and `youtube-dl` uses `exefiles` which I did not see documented. Has this key changed or is everything in order?