### PR TITLE
Add Zren/mpv-osc-tethys

### DIFF
--- a/mpv_script_directory.json
+++ b/mpv_script_directory.json
@@ -1274,6 +1274,23 @@
         "stars": 17,
         "sharedrepo": false
     },
+    "github:Zren/mpv-osc-tethys": {
+        "name": "mpv-osc-tethys",
+        "url": "https://github.com/Zren/mpv-osc-tethys",
+        "type": "lua script",
+        "install": "git",
+        "receiving_url": "https://github.com/Zren/mpv-osc-tethys",
+        "install_dir": "github/Zren/mpv-osc-tethys",
+        "desc": "An OSC UI replacement for MPV with icons from the bomi video player. Also contains thumbnail preview and a picture-in-picture button.",
+        "scriptfiles": [
+            "mpv_thumbnail_script_server.lua",
+            "osc_tethys.lua"
+        ],
+        "install-notes": "Note: Because this script replaces the built-in OSC, you will have to set osc=no in your mpv's main config file.\nSee the scripts site for configuration options:\nhttps://github.com/Zren/mpv-osc-tethys",
+        "os": [],
+        "stars": 37,
+        "sharedrepo": false
+    },
     "github:jgreco/mpv-pdf": {
         "name": "mpv-pdf",
         "url": "https://github.com/jgreco/mpv-pdf",


### PR DESCRIPTION
Based my entry on `mpv_thumbnail_script` as I bundle a patched version of it's `server.lua` for the thumbnails.

-----

PR requested by @z8512 at https://github.com/Zren/mpv-osc-tethys/issues/8.

Note: While using `mpv_thumbnail_script` as an example, I noticed that it's trying to install the generated lua files in the "release page". The source code repo that is cloned does not have those files, so I'm guessing that `mpv_thumbnail_script` doesn't install properly with your package manager.

That's besides the point though, as the last generated lua release by TheAMM is missing a crucial bugfix (which is part of the reason I bundle my own `server.lua`).

* https://github.com/TheAMM/mpv_thumbnail_script
* https://github.com/TheAMM/mpv_thumbnail_script/releases
* https://github.com/TheAMM/mpv_thumbnail_script/network
