### PR TITLE
Update uosc config

### DIFF
--- a/mpv_script_directory.json
+++ b/mpv_script_directory.json
@@ -2559,15 +2559,22 @@
         "stars": 5,
         "sharedrepo": false
     },
-    "github:darsain/uosc": {
+    "github:tomasklaen/uosc": {
         "name": "uosc",
-        "url": "https://github.com/darsain/uosc",
+        "url": "https://github.com/tomasklaen/uosc",
         "type": "lua script",
-        "receiving_url": "https://github.com/darsain/uosc",
-        "install_dir": "github/darsain/uosc",
-        "desc": "Minimalist proximity based UI replacement. Video preview.",
+        "receiving_url": "https://github.com/tomasklaen/uosc",
+        "install_dir": "github/tomasklaen/uosc",
+        "scriptfiles": [
+            "scripts/uosc.lua"
+        ],
+        "fontfiles": [
+            "fonts/uosc_icons.otf",
+            "fonts/uosc_textures.ttf"
+        ],
+        "desc": "Feature-rich minimalist proximity-based UI replacement.",
         "os": [],
-        "stars": 68,
+        "stars": 295,
         "sharedrepo": false
     },
     "github:mfcc64/mpv-scripts/visualizer.lua": {


### PR DESCRIPTION
uosc has a stable version archive download: https://github.com/tomasklaen/uosc/releases/latest/download/uosc.zip

But as I'm reading the docs, zip installs are not supported? So I've just updated the current config that installs from main branch. This might lead to people installing development versions, but I guess better than nothing.

Also how do you handle config files? I was afraid to put the default config there in fear that it might overwrite peoples' current one.