### PR TITLE
Add Notify script by teraflops

### DIFF
--- a/mpv_script_directory.json
+++ b/mpv_script_directory.json
@@ -3102,5 +3102,12 @@
         "os": [],
         "stars": 4,
         "install-notes": "Dependency: auto-editor (pip install auto-editor)"
+    },
+    {
+      "name": "Notify",
+      "description": "Shows notifications with metadata and cover art in MPV using inference models",
+      "author": "teraflops",
+      "url": "https://gitlab.com/teraflops/mpvcovergrabber",
+      "tags": ["notifications", "audio", "video", "metadata"]
     }
 }


### PR DESCRIPTION
This PR adds the Notify script. It shows notifications with metadata and cover art for both audio and video files in MPV. It supports local covers, Last.fm, TMDB, and uses a local language model for metadata cleanup.